### PR TITLE
clean up getConfig storage service calls

### DIFF
--- a/src/components/EvidenceWrapper.vue
+++ b/src/components/EvidenceWrapper.vue
@@ -261,7 +261,6 @@ export default {
   },
   created() {
     this.fetchItems();
-    this.getConfig();
     this.getCredentials();
   },
   computed: {
@@ -451,10 +450,6 @@ export default {
         const sessionItems = await this.$storageService.getItems();
         this.$store.commit("setSessionItemsFromExternalWindow", sessionItems);
       }
-    },
-    async getConfig() {
-      const config = await this.$storageService.getConfig();
-      this.$store.commit("config/setFullConfig", config);
     },
     async getCredentials() {
       const credentials = await this.$storageService.getCredentials();

--- a/src/components/ExportPanel.vue
+++ b/src/components/ExportPanel.vue
@@ -165,7 +165,6 @@ export default {
   },
   methods: {
     async exportSession(type) {
-      const { logo } = await this.$storageService.getConfig();
       const data = {
         title: this.$store.state.case.title,
         charter: this.$store.state.case.charter,
@@ -174,8 +173,8 @@ export default {
         timer: this.$store.state.session.timer,
         started: this.$store.state.session.started,
         ended: this.$store.state.session.ended,
-        reportLogo: logo && logo.enabled,
-        logoPath: logo && logo.path,
+        reportLogo: this.config.logo && this.config.logo.enabled,
+        logoPath: this.config.logo && this.config.logo.path,
         type: type,
       };
       if (this.$isElectron) {

--- a/src/components/ExportSessionButton.vue
+++ b/src/components/ExportSessionButton.vue
@@ -168,7 +168,6 @@ export default {
   },
   methods: {
     async exportSession(type) {
-      const { logo } = await this.$storageService.getConfig();
       const data = {
         title: this.$store.state.case.title,
         charter: this.$store.state.case.charter,
@@ -177,8 +176,8 @@ export default {
         timer: this.$store.state.session.timer,
         started: this.$store.state.session.started,
         ended: this.$store.state.session.ended,
-        reportLogo: logo && logo.enabled,
-        logoPath: logo && logo.path,
+        reportLogo: this.config.logo && this.config.logo.enabled,
+        logoPath: this.config.logo && this.config.logo.path,
         type: type,
       };
       if (this.$isElectron) {

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -264,6 +264,7 @@ export default {
       credentials: "auth/credentials",
       isAuthenticated: "auth/isAuthenticated",
       loggedInServices: "auth/loggedInServices",
+      config: "config/fullConfig"
     }),
     quickTestHotkey() {
       return this.$hotkeyHelpers.findBinding("home.quickTest", this.hotkeys);
@@ -285,16 +286,9 @@ export default {
     if (this.$isElectron) {
       // handle electron menu -> New Session
       this.$electronService.onNewSession(this.newSession);
-      this.$electronService.onConfigChange(() => {
-        this.getConfig();
-      });
     }
   },
   methods: {
-    async getConfig() {
-      const config = await this.$storageService.getConfig();
-      this.$store.commit("config/setFullConfig", config);
-    },
     async newSession() {
       this.$store.commit("clearState");
       await this.$store.commit("setSessionQuickTest", false);

--- a/src/components/dialogs/AddEvidenceDialog.vue
+++ b/src/components/dialogs/AddEvidenceDialog.vue
@@ -543,7 +543,6 @@ export default {
   },
   created() {
     this.fetchItems();
-    this.getConfig();
     this.getCredentials();
   },
   computed: {
@@ -727,10 +726,6 @@ export default {
         const sessionItems = await this.$storageService.getItems();
         this.$store.commit("setSessionItemsFromExternalWindow", sessionItems);
       }
-    },
-    async getConfig() {
-      const config = await this.$storageService.getConfig();
-      this.$store.commit("config/setFullConfig", config);
     },
     async getCredentials() {
       const credentials = await this.$storageService.getCredentials();

--- a/src/components/dialogs/EditEvidenceDialog.vue
+++ b/src/components/dialogs/EditEvidenceDialog.vue
@@ -353,7 +353,6 @@ export default {
   },
   created() {
     this.fetchItems();
-    this.getConfig();
     this.getCredentials();
     // if (this.$isElectron) {
     this.activeSession();
@@ -485,10 +484,6 @@ export default {
     },
     updateProcessing(value) {
       this.processing = value;
-    },
-    async getConfig() {
-      const config = await this.$storageService.getConfig();
-      this.$store.commit("config/setFullConfig", config);
     },
     async getCredentials() {
       const credentials = await this.$storageService.getCredentials();

--- a/src/views/AuthenticationView.vue
+++ b/src/views/AuthenticationView.vue
@@ -20,6 +20,8 @@
 </template>
 
 <script>
+import { mapGetters } from "vuex";
+
 export default {
   name: "AuthenticationView",
   components: {},
@@ -31,6 +33,9 @@ export default {
     };
   },
   computed: {
+    ...mapGetters({
+      config: "config/fullConfig",
+    }),
     currentTheme() {
       if (this.$vuetify.theme.dark) {
         return this.$vuetify.theme.themes.dark;
@@ -48,7 +53,6 @@ export default {
     },
   },
   created() {
-    this.getConfig();
     this.getCredentials();
   },
   beforeRouteEnter(to, from, next) {
@@ -58,15 +62,10 @@ export default {
   },
   mounted() {
     if (this.$isElectron) {
-      this.$electronService.onConfigChange(this.getConfig);
       this.$electronService.onCredentialChange(this.getCredentials);
     }
   },
   methods: {
-    async getConfig() {
-      const config = await this.$storageService.getConfig();
-      this.$store.commit("config/setFullConfig", config);
-    },
     async getCredentials() {
       const credentials = await this.$storageService.getCredentials();
       this.$store.commit("auth/setCredentials", credentials);

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -382,6 +382,7 @@ export default {
       credentials: "auth/credentials",
       isAuthenticated: "auth/isAuthenticated",
       loggedInServices: "auth/loggedInServices",
+      config: "config/fullConfig",
     }),
     currentTheme() {
       if (this.$vuetify.theme.dark) {
@@ -421,16 +422,9 @@ export default {
     if (this.$isElectron) {
       // handle electron menu -> New Session
       this.$electronService.onNewSession(this.newSession);
-      this.$electronService.onConfigChange(() => {
-        this.getConfig();
-      });
     }
   },
   methods: {
-    async getConfig() {
-      const config = await this.$storageService.getConfig();
-      this.$store.commit("config/setFullConfig", config);
-    },
     async newSession() {
       this.$store.commit("clearState");
       this.$store.commit("setSessionQuickTest", false);

--- a/src/views/LowProfileView.vue
+++ b/src/views/LowProfileView.vue
@@ -39,6 +39,7 @@ export default {
     ...mapGetters({
       credentials: "auth/credentials",
       items: "sessionItems",
+      config: "config/fullConfig",
     }),
   },
   data() {
@@ -73,7 +74,6 @@ export default {
     }
   },
   mounted() {
-    this.getConfig();
     // this.getCredentials();
 
     if (!window.ipc) return;
@@ -88,15 +88,6 @@ export default {
     });
   },
   methods: {
-    getConfig() {
-      if (!window.ipc) return;
-
-      window.ipc
-        .invoke(IPC_HANDLERS.PERSISTENCE, { func: IPC_FUNCTIONS.GET_CONFIG })
-        .then((result) => {
-          this.config = result;
-        });
-    },
     getCredentials() {
       if (!window.ipc) return;
 

--- a/src/views/ResultView.vue
+++ b/src/views/ResultView.vue
@@ -79,7 +79,6 @@ export default {
   },
   created() {
     this.fetchItems();
-    this.getConfig();
     this.getCredentials();
   },
   mounted() {
@@ -90,11 +89,9 @@ export default {
 
     if (this.$isElectron) {
       this.$electronService.onDataChange(this.fetchItems);
-      this.$electronService.onConfigChange(this.getConfig);
       this.$electronService.onCredentialChange(this.getCredentials);
       this.$electronService.onMetaChange(() => {
         this.fetchItems();
-        this.getConfig();
         this.getCredentials();
       });
     }
@@ -102,6 +99,7 @@ export default {
   computed: {
     ...mapGetters({
       items: "sessionItems",
+      config: "config/fullConfig",
     }),
     currentTheme() {
       if (this.$vuetify.theme.dark) {
@@ -134,10 +132,6 @@ export default {
       } else {
         // todo check if something required for web version here
       }
-    },
-    async getConfig() {
-      const config = await this.$storageService.getConfig();
-      this.$store.commit("config/setFullConfig", config);
     },
     async getCredentials() {
       const credentials = await this.$storageService.getCredentials();

--- a/src/views/SettingView.vue
+++ b/src/views/SettingView.vue
@@ -89,6 +89,7 @@ export default {
   computed: {
     ...mapGetters({
       isAuthenticated: "auth/isAuthenticated",
+      config: "config/fullConfig",
     }),
     currentTheme() {
       if (this.$vuetify.theme.dark) {
@@ -161,14 +162,13 @@ export default {
     if (this.$isElectron) {
       this.getMetadata();
     }
-    this.getConfig();
     this.getCredentials();
   },
   mounted() {
     if (this.$isElectron) {
       this.$root.$on("change-meta", () => {
         this.getMetadata();
-        this.getConfig().then(() => this.updateConfig(this.config));
+        this.updateConfig(this.config);
         this.getCredentials().then(() =>
           this.updateCredentials(this.credentials)
         );
@@ -178,10 +178,6 @@ export default {
   methods: {
     async getMetadata() {
       this.metadata = await this.$storageService.getMetaData();
-    },
-    async getConfig() {
-      this.config = await this.$storageService.getConfig();
-      this.$store.commit("config/setFullConfig", this.config);
     },
     updateConfig(value) {
       this.config = value;


### PR DESCRIPTION
## Cleanup Storage Service Calls and Centralize getConfig in App.vue

## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Issue Number: N/A

The `getConfig` function was being called in multiple places throughout the codebase, leading to redundant calls and scattered configuration logic. 

## What is the new behavior?

- Cleaned up storage service calls to improve efficiency and consistency.
- Centralized the `getConfig` call to only occur in `App.vue`, removing it from other locations.
- Integrated the configuration logic into Vuex for better state management and accessibility across the application.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Does this introduce UI changes? If so, have they been tested on both dark and light modes?

- [ ] Yes
- [x] No

## Other information

No functional changes were made; this is purely a refactoring effort to improve code maintainability and centralize configuration handling.